### PR TITLE
EVSREPEXP-263. Adjusting the services and controller to adapt to result set changes

### DIFF
--- a/service/src/main/java/gov/nih/nci/evs/report/exporter/controller/PropertyController.java
+++ b/service/src/main/java/gov/nih/nci/evs/report/exporter/controller/PropertyController.java
@@ -1,5 +1,7 @@
 package gov.nih.nci.evs.report.exporter.controller;
 
+import java.util.Arrays;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -21,7 +23,9 @@ public class PropertyController {
 
 	@GetMapping("/properties")
 	public RestPropertyMetadata[] getPropertyMeta(Model model){
-		return service.getRestProperties(CommonServices.getRestTemplate());
+		RestPropertyMetadata[] props = service.getRestProperties(CommonServices.getRestTemplate());
+		Arrays.sort(props);
+		return props;
 	}
 	
 	@PostMapping("/properties")

--- a/service/src/main/java/gov/nih/nci/evs/report/exporter/model/RestPropertyMetadata.java
+++ b/service/src/main/java/gov/nih/nci/evs/report/exporter/model/RestPropertyMetadata.java
@@ -3,7 +3,7 @@ package gov.nih.nci.evs.report.exporter.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
-public class RestPropertyMetadata {
+public class RestPropertyMetadata implements Comparable<RestPropertyMetadata>{ 
 /**
  * This is a property id
  */
@@ -60,6 +60,11 @@ public String getVersion() {
 }
 public void setVersion(String version) {
 	this.version = version;
+}
+
+@Override
+public int compareTo(RestPropertyMetadata o) {
+	return this.getName().compareTo(o.getName());
 }
 
 

--- a/service/src/main/java/gov/nih/nci/evs/report/exporter/service/EVSAPIBaseService.java
+++ b/service/src/main/java/gov/nih/nci/evs/report/exporter/service/EVSAPIBaseService.java
@@ -28,6 +28,9 @@ public class EVSAPIBaseService {
     @Value("${BASE_URL}")
     private String baseURL;
     
+    @Value("${BASE_METAD_URL}")
+    private String baseMetaURL;
+    
     @Value("${CHILDREN}")
     private String children;
     
@@ -48,6 +51,12 @@ public class EVSAPIBaseService {
 	
 	@Value("${REST_PROP_URL}")
 	private String propURL;
+	
+	@Value("${REST_SYN_URL}")
+	private String synURL;
+	
+	@Value("${REST_DEF_URL}")
+	private String defURL;
 	
 	@Value("${REST_PROP_FILTER_LIST}")
 	private String filterList;
@@ -127,7 +136,23 @@ public class EVSAPIBaseService {
 	public RestPropertyMetadata[] getRestProperties(RestTemplate template){
 		return template
 		.getForObject(
-		 propURL
+		 baseMetaURL + propURL
+				,RestPropertyMetadata[].class);
+
+	}
+	
+	public RestPropertyMetadata[] getRestSynonyms(RestTemplate template){
+		return template
+		.getForObject(
+		 baseMetaURL + synURL
+				,RestPropertyMetadata[].class);
+
+	}
+	
+	public RestPropertyMetadata[] getRestDefinitions(RestTemplate template){
+		return template
+		.getForObject(
+		 baseMetaURL + defURL
 				,RestPropertyMetadata[].class);
 
 	}

--- a/service/src/main/java/gov/nih/nci/evs/report/exporter/service/TerminologyPropertyService.java
+++ b/service/src/main/java/gov/nih/nci/evs/report/exporter/service/TerminologyPropertyService.java
@@ -26,7 +26,15 @@ public class TerminologyPropertyService {
 	public RestPropertyMetadata[] getRestProperties(RestTemplate template){
 		RestPropertyMetadata[] propMeta = 
 				getFilteredList(service.getRestProperties(template));
-		return propMeta;
+		RestPropertyMetadata[] synMeta = 
+				getFilteredList(service.getRestSynonyms(template));
+		RestPropertyMetadata[] defMeta = 
+				getFilteredList(service.getRestDefinitions(template));
+		
+		return Stream
+				.of(propMeta,synMeta,defMeta)
+				.flatMap(Stream::of)
+				.toArray(RestPropertyMetadata[]::new);
 	}
 	
 	public RestPropertyMetadata[] getFilteredList(RestPropertyMetadata[] propMeta) {

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,7 +1,10 @@
-REST_PROP_URL=https://api-evsrest-dev.nci.nih.gov/api/v1/metadata/ncit/properties?include=minimal
+REST_PROP_URL=properties?include=minimal
+REST_SYN_URL=synonymTypes?include=minimal
+REST_DEF_URL=definitionTypes?include=minimal
 REST_PROP_FILTER_LIST=BioCarta_ID,Extensible_List,FDA_Table,Gene_Encodes_Product,Homologous_Gene,Image_Link,Legacy Concept Name,NICHD_Hierarchy_Term,OLD_ASSOCIATION,OLD_CHILD,OLD_KIND,OLD_PARENT,OLD_ROLE,OLD_STATE,Publish_Value_Set,Relative_Enzyme_Activity,Term_Browser_Value_Set_Description,Use_For,Value_Set_Pair,Preferred_Name
 REST_ROOT_FILTER_LIST=C28428
 BASE_URL=https://api-evsrest-dev.nci.nih.gov/api/v1/concept/ncit/
+BASE_METAD_URL=https://api-evsrest-dev.nci.nih.gov/api/v1/metadata/ncit/
 CHILDREN=/children
 DESCENDANTS=/descendants?maxLevel=
 PARENTS=/parents


### PR DESCRIPTION
Synonyms and Definition names were removed from the property metadata in the EVS API.  We'll adjust to include them back in our list by calling the appropriate resources.